### PR TITLE
Updated to target Android 9.0 Pie (API 28)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ cache:
   - $HOME/.android/build-cache
 env:
   global:
-  - API_LEVEL=27
+  - API_LEVEL=28
   - ANDROID_EMULATOR_API_LEVEL=23
-  - ANDROID_BUILD_TOOLS_VERSION=27.0.3
+  - ANDROID_BUILD_TOOLS_VERSION=28.0.2
   - ANDROID_ABI=google_apis/armeabi-v7a
   - ADB_INSTALL_TIMEOUT=20
   - ANDROID_TARGET=android-23
@@ -37,7 +37,7 @@ before_install:
 - mkdir "$ANDROID_HOME/licenses" || true
 - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
 - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-- yes | sdkmanager "platforms;android-27" # Temporary fix for checksum mismatch (travis-ci/#8874)
+- yes | sdkmanager "platforms;android-28" # Temporary fix for checksum mismatch (travis-ci/#8874)
 - openssl aes-256-cbc -K $encrypted_cec42bb3ef77_key -iv $encrypted_cec42bb3ef77_iv -in google-services.json.enc -out app/google-services.json -d
 - android list targets
 - chmod +x gradlew

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ apply plugin: 'io.fabric'
 def isTravis = System.getenv("TRAVIS")
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         applicationId "com.itachi1706.busarrivalsg"
         minSdkVersion 15
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 320
         versionName "3.1.1"
         vectorDrawables.useSupportLibrary = true
@@ -49,8 +49,7 @@ android {
 }
 
 ext {
-    supportLibraryVersion = '27.1.1'
-    playServicesVersion = '15.0.0'
+    supportLibraryVersion = '28.0.0+'
 }
 
 dependencies {
@@ -69,10 +68,10 @@ dependencies {
     implementation 'com.getpebble:pebblekit:3.0.0'
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.google.android.gms:play-services-maps:15.0.1'
-    implementation 'com.google.android.gms:play-services-auth:15.0.1'
-    implementation 'com.google.firebase:firebase-auth:16.0.2'
+    implementation 'com.google.android.gms:play-services-auth:16.0.0'
+    implementation 'com.google.firebase:firebase-auth:16.0.3'
     implementation 'com.google.firebase:firebase-core:16.0.1'
-    implementation 'com.google.firebase:firebase-perf:16.0.0'
+    implementation 'com.google.firebase:firebase-perf:16.1.0'
     implementation 'de.psdev.licensesdialog:licensesdialog:1.8.3'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,8 +23,10 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:ignore="UnusedAttribute">
         <activity
             android:name=".MainMenuActivity"
             android:label="@string/app_name">
@@ -100,6 +102,9 @@
         <activity android:name=".BusStopsTabbedActivity"
             android:label="@string/title_activity_add_bus_stops"
             android:theme="@style/AppTheme.NoActionBar"/>
+
+        <!-- Required because FOR SOME REASON Google Maps is using the deprecated Apache HTTP? WTF Google? -->
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
     </application>
 
 </manifest>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <!-- For all API usage as API is HTTP only for now -->
+        <domain includeSubdomains="true">api.itachi1706.com</domain>
+        <domain includeSubdomains="true">itachi1706.com</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
- Added HTTP whitelist to retrieve Pebble installers from a non-HTTP site
- Added fix where Google Maps will crash when targeting API 28 as they are using the deprecated Apache HTTP library
- Closes #117