### PR TITLE
SGBUSAND-185 Fixed crash with handlers in the NTU Bus View

### DIFF
--- a/app/src/main/java/com/itachi1706/busarrivalsg/NTUBusActivity.java
+++ b/app/src/main/java/com/itachi1706/busarrivalsg/NTUBusActivity.java
@@ -177,9 +177,9 @@ public class NTUBusActivity extends AppCompatActivity implements OnMapReadyCallb
 
         mapView.onPause();
         shouldAutoRefresh = false;
-        refreshHandler.removeMessages(REFRESH_TASK);
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(receiver);
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(publicBusReceiver);
+        if (refreshHandler != null) refreshHandler.removeMessages(REFRESH_TASK);
+        if (receiver != null) LocalBroadcastManager.getInstance(this).unregisterReceiver(receiver);
+        if (publicBusReceiver != null) LocalBroadcastManager.getInstance(this).unregisterReceiver(publicBusReceiver);
     }
 
     @Override


### PR DESCRIPTION
This is caused by the refresh handler somehow not initializing hence when we try to use it, it crashes

Fixed SGBUSAND-185