### PR TITLE
[SGBUSAND-234] Fixed sharing application logs crashing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0-alpha4', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'com.itachi1706.appupdater:appupdater:2.2.3'
+    implementation 'com.itachi1706.appupdater:appupdater:2.2.4'
     implementation 'com.itachi1706.helpers:helperlib:1.1.1'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'


### PR DESCRIPTION
This was due to it being too large for the Android Intent System to handle. The fix was to save it and share as a text file if it is too long

Closes SGBUSAND-234

Took 4 minutes