### PR TITLE
SGBUSAND-300 Prevent null returns of empty data

### DIFF
--- a/app/src/main/java/com/itachi1706/busarrivalsg/Database/BusStopsDB.java
+++ b/app/src/main/java/com/itachi1706/busarrivalsg/Database/BusStopsDB.java
@@ -192,7 +192,7 @@ public class BusStopsDB extends SQLiteOpenHelper {
 
         Cursor cursor = db.rawQuery(query, null);
         if (cursor.getCount() == 0)
-            return null;
+            return result; // Return empty arraylist instead of null
         if (cursor.moveToFirst()){
             do {
                 result.add(getBusStopJsonObject(cursor));


### PR DESCRIPTION
If data is empty, currently it returns null which crashes the app. This change returns an empty array instead